### PR TITLE
Making RateLimit configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.coldis</groupId>
         <artifactId>configuration</artifactId>
-        <version>2.0.70</version>
+        <version>2.0.72</version>
     </parent>
     <groupId>org.coldis.library</groupId>
     <artifactId>service</artifactId>

--- a/src/main/java/org/coldis/library/service/ratelimit/RateLimit.java
+++ b/src/main/java/org/coldis/library/service/ratelimit/RateLimit.java
@@ -23,27 +23,27 @@ public @interface RateLimit {
 	/**
 	 * Period (in seconds) for the limit.
 	 */
-	int period() default 60;
+	String period() default "60";
 
 	/**
 	 * Backoff period is the period by default.
 	 */
-	int backoffPeriod() default -1;
+	String backoffPeriod() default "-1";
 
 	/**
 	 * Limit for the period.
 	 */
-	long limit();
+	String limit();
 
 	/**
 	 * If the limit is local to the JVM or centralized.
 	 */
-	boolean local() default true;
+	String local() default "true";
 
 	/**
 	 * Relative error margin. Only applies to central limit.
 	 */
-	long errorMargin() default 10;
+	String errorMargin() default "10";
 
 	/**
 	 * If the exception type should be changed.

--- a/src/main/java/org/coldis/library/service/ratelimit/RateLimitAutoConfiguration.java
+++ b/src/main/java/org/coldis/library/service/ratelimit/RateLimitAutoConfiguration.java
@@ -1,4 +1,20 @@
 package org.coldis.library.service.ratelimit;
 
+import org.aspectj.lang.Aspects;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+
+@Order(100)
+@Configuration
 public class RateLimitAutoConfiguration {
+    /**
+     * Create rate limit interceptor.
+     *
+     * @return the rate limit interceptor
+     */
+    @Bean(name = "rateLimitInterceptor")
+    public RateLimitInterceptor createRateLimitInterceptor() {
+        return Aspects.aspectOf(RateLimitInterceptor.class);
+    }
 }

--- a/src/main/java/org/coldis/library/service/ratelimit/RateLimitAutoConfiguration.java
+++ b/src/main/java/org/coldis/library/service/ratelimit/RateLimitAutoConfiguration.java
@@ -1,0 +1,4 @@
+package org.coldis.library.service.ratelimit;
+
+public class RateLimitAutoConfiguration {
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -41,3 +41,6 @@ spring.test.context.failure.threshold=1000000
 
 # Properties.
 org.coldis.library.test.data-installer-attribute=33
+
+rate.limit.configurable-limit=25
+rate.limit.configurable-period=3


### PR DESCRIPTION

-     Bumped persistence and configuration versions
-     Migrated long RateLimit parameters to string
-     Created RateLimitInterceptorAutoConfiguration
-     Used spring context resolution to be able to process parameters in RateLimitInterceptor

