### PR TITLE
Removing the @Transactional tag from the fetchPeriodCacheable method

### DIFF
--- a/src/main/java/org/coldis/library/service/statistics/StatisticsEventSummaryServiceComponent.java
+++ b/src/main/java/org/coldis/library/service/statistics/StatisticsEventSummaryServiceComponent.java
@@ -125,10 +125,6 @@ public class StatisticsEventSummaryServiceComponent {
 	 * @param  parallel             Fetch the per-bucket reads concurrently.
 	 * @return                      The window's summaries.
 	 */
-	@Transactional(
-			propagation = Propagation.NOT_SUPPORTED,
-			readOnly = true
-	)
 	protected List<StatisticsEventSummary> fetchPeriodCacheable(
 			final String context,
 			final String dimensionName,


### PR DESCRIPTION
Remove a anotação `@Transactional(NOT_SUPPORTED, readOnly)` de `fetchPeriodCacheable` introduzida em 2.0.283, que disparava falha de re-weave (`key not  found in wovenClassFile`) em consumers que usam `<weaveDependencies>` — limitação conhecida do Spring com around advice ([spring-projects/spring-framework#13906](https://github.com/spring-projects/spring-framework/issues/13906)).